### PR TITLE
remove sender from the dbus match string

### DIFF
--- a/main.c
+++ b/main.c
@@ -211,7 +211,6 @@ static void setup_sleep_listener(void) {
 
 	char str[256];
 	const char *fmt = "type='signal',"
-		"sender='org.freedesktop.login1',"
 		"interface='org.freedesktop.login1.%s',"
 		"member='%s'," "path='%s'";
 


### PR DESCRIPTION
the signals didn't have a name for the sender.

from `sudo busctl monitor` I see:

```
‣ Type=signal  Endian=l  Flags=1  Version=1  Priority=0 Cookie=944
  Sender=:1.3  Path=/org/freedesktop/login1  Interface=org.freedesktop.login1.Manager  Member=PrepareForSleep
  UniqueName=:1.3
  MESSAGE "b" {
          BOOLEAN true;
  };
```
and
```
‣ Type=signal  Endian=l  Flags=1  Version=1  Priority=0 Cookie=950
  Sender=:1.3  Path=/org/freedesktop/login1  Interface=org.freedesktop.login1.Manager  Member=PrepareForSleep
  UniqueName=:1.3
  MESSAGE "b" {
          BOOLEAN false;
  };
```

OS is ArchLinux with systemd 240.34-3