### PR TITLE
use sd_bus_match_signal instead of sd_bus_add_match

### DIFF
--- a/main.c
+++ b/main.c
@@ -209,18 +209,12 @@ static void setup_sleep_listener(void) {
 		return;
 	}
 
-	char str[256];
-	const char *fmt = "type='signal',"
-		"sender='org.freedesktop.login1',"
-		"interface='org.freedesktop.login1.%s',"
-		"member='%s'," "path='%s'";
-
-	snprintf(str, sizeof(str), fmt, "Manager", "PrepareForSleep",
-			"/org/freedesktop/login1");
-	ret = sd_bus_add_match(bus, NULL, str, prepare_for_sleep, NULL);
+	ret = sd_bus_match_signal(bus, NULL, "org.freedesktop.login1",
+                "/org/freedesktop/login1", "org.freedesktop.login1.Manager",
+                "PrepareForSleep", prepare_for_sleep, NULL);
 	if (ret < 0) {
 		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus match");
+		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus signal match");
 		return;
 	}
 	acquire_sleep_lock();


### PR DESCRIPTION
This also fixes a bug where the signals didn't have a name for the sender,
sd_bus_match_signal handles that case, where sd_bus_add_match did not
match the signals.

from `sudo busctl monitor` I see:

```
‣ Type=signal  Endian=l  Flags=1  Version=1  Priority=0 Cookie=944
  Sender=:1.3  Path=/org/freedesktop/login1  Interface=org.freedesktop.login1.Manager  Member=PrepareForSleep
  UniqueName=:1.3
  MESSAGE "b" {
          BOOLEAN true;
  };
```
and
```
‣ Type=signal  Endian=l  Flags=1  Version=1  Priority=0 Cookie=950
  Sender=:1.3  Path=/org/freedesktop/login1  Interface=org.freedesktop.login1.Manager  Member=PrepareForSleep
  UniqueName=:1.3
  MESSAGE "b" {
          BOOLEAN false;
  };
```

OS is ArchLinux with systemd 240.34-3