### PR TITLE
Use -Wvla flag to prevent usage of VLAs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ add_project_arguments(
 		'-Wno-unused-parameter',
 		'-Wno-unused-result',
 		'-Wundef',
+		'-Wvla',
 	],
 	language: 'c',
 )


### PR DESCRIPTION
See https://github.com/swaywm/sway/pull/3438.

No VLAs are used here.

Aside from the WIP pull request on wlroots, this should be the last one.