### PR TITLE
Replace old Sway references with swayidle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,18 @@ See the man page, `swayidle(1)`, for instructions on configuring swayidle.
 ## Release Signatures
 
 Releases are signed with [B22DA89A](http://pgp.mit.edu/pks/lookup?op=vindex&search=0x52CB6609B22DA89A)
-and published [on GitHub](https://github.com/swaywm/sway/releases). swayidle
+and published [on GitHub](https://github.com/swaywm/swayidle/releases). swayidle
 releases are managed independently of sway releases.
 
 ## Installation
 
 ### From Packages
 
-Sway is available in many distributions. Try installing the "swayidle" package
-for yours. If it's not available, check out [this wiki
-page](https://github.com/swaywm/sway/wiki/Unsupported-packages) for information
-on installation for your distributions.
+Swayidle is available in many distributions. Try installing the "swayidle"
+package for yours.
 
-If you're interested in packaging sway for your distribution, stop by the IRC
-channel or shoot an email to sir@cmpwn.com for advice.
+If you're interested in packaging swayidle for your distribution, stop by the
+IRC channel or shoot an email to sir@cmpwn.com for advice.
 
 ### Compiling from Source
 

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -69,8 +69,8 @@ It will also lock your screen before your computer goes to sleep.
 # AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
-source contributors. For more information about sway development, see
-https://github.com/swaywm/sway.
+source contributors. For more information about swayidle development, see
+https://github.com/swaywm/swayidle.
 
 # SEE ALSO
 


### PR DESCRIPTION
Basically the same as https://github.com/swaywm/swaylock/pull/21, but it only affects documentation.

Two notes (just FYI, I don't want tho take a position here):
- Swayidle currently does not provide a version parameter (`-v`, `--version`). I don't think this is strictly necessary but it might make sense for users and bug reports since swayidle is now an independent package.
- The man page still references a lot of the man pages from Sway: https://github.com/swaywm/swayidle/blob/ec102c1478ab077abec288e70c931d2502c836b7/swayidle.1.scd#L77
  These seem only relevant for the [example](https://github.com/swaywm/swayidle/blob/ec102c1478ab077abec288e70c931d2502c836b7/swayidle.1.scd#L55). I think that `sway`, `sway-input`, and `sway-bar` are not required anymore and `swaylock` is used in the example but not in this list. It might make sense to drop all of them or update the list accordingly.

Hope this helps :)