### PR TITLE
Allow downstream to disable manpages even if scdoc is found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project(
 	'swayidle',
 	'c',
 	license: 'MIT',
+	meson_version: '>=0.48.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -25,7 +26,7 @@ wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')
 
-scdoc = find_program('scdoc', required: false)
+scdoc = find_program('scdoc', required: get_option('man-pages'))
 wayland_scanner = find_program('wayland-scanner')
 
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions.')


### PR DESCRIPTION
See https://github.com/swaywm/sway/pull/3452. `gdk-pixbuf` is already an option since https://github.com/swaywm/swaylock/pull/22.
