### PR TITLE
add a microsecond sleep after exec of 'before-sleep'

### DIFF
--- a/main.c
+++ b/main.c
@@ -167,6 +167,8 @@ static int prepare_for_sleep(sd_bus_message *msg, void *userdata,
 
 	if (state.before_sleep_cmd) {
 		cmd_exec(state.before_sleep_cmd);
+		// sleep for a microsecond, to allow the command to really spawn
+		nanosleep((const struct timespec[]){{0, 1000000L}}, NULL);
 	}
 	swayidle_log(LOG_DEBUG, "Prepare for sleep done");
 


### PR DESCRIPTION
when using before-sleep swayidle inhibits logind to go to sleep, before
it runs a command, typically swaylock.

but without this artificial microsecond sleep swayidle would release the
inhibit lock too fast, and it would happen (more often than not) for swaylock
to not have the time to spawn and lock the screen. then, on resume for a moment
the screen contents are visible before swaylock finally locks it.

the time is arbitrary selected, seemed long enough for computers and
short enough for people. seemed to work fine on my i7-5600U / MZ7TE256
sata ssd.

a more proper solution would be if swaylock would inform swayidle that
it did lock the screen, but we don't know that we run swaylock always,
and there's no generic protocol to know if a program is activated
(apart from systemd's one).