### PR TITLE
toggle all timers on SIGUSR2

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -30,6 +30,9 @@ command line.
 
 Sending SIGUSR1 to swayidle will immediately enter idle state.
 
+Sending SIGUSR2 to swayidle will disable all timer-based triggers. Sending that
+signal again will reenable those triggers.
+
 # EVENTS
 
 *timeout* <timeout> <timeout command> [resume <resume command>]


### PR DESCRIPTION
This allows a minimal "presentation mode" where the screen will never be
locked.

This could be merged as-is, but I am opened to suggestion. Using a signal to toggle sounds the right way
to do this to me, but there is no way to ask swayidle about the status of the triggers. 

To do this I see multiple ways
* printf on SIGUSR2 with the new state
* some sort of dbus API, but that would need dbus and would force swayidle to have a dbus API, which it doesn't have so far.

I am opened to suggestions... 