### PR TITLE
Update zsh completions

### DIFF
--- a/completions/zsh/_swayidle
+++ b/completions/zsh/_swayidle
@@ -8,10 +8,11 @@ local events=('timeout:Execute timeout command if there is no activity for timeo
 local resume=('resume:Execute command when there is activity again')
 
 if (($#words <= 2)); then
+	_describe -t "events" 'swayidle' events
 	_arguments -C \
 			   '(-h --help)'{-h,--help}'[Show help message and quit]' \
-			   '(-d)'-d'[Enable debug output]'
-	_describe -t "events" 'swayidle' events
+			   '(-d)'-d'[Enable debug output]' \
+			   '(-w)'-w'[Wait for command to finish executing before continuing]'
 
 elif  [[ "$words[-3]" == before-sleep || "$words[-3]" == resume ]]; then
 	_describe -t "events" 'swayidle' events


### PR DESCRIPTION
Include the -w option and use describe before arguments.

It's best to use \_arguments last when invoked to let its return code propagate to compsys so the completion won't accidentally be invoked again. Try `swayidle -<TAB>` to see what I mean.