### PR TITLE
Reset timer on SIGUSR2

### DIFF
--- a/main.c
+++ b/main.c
@@ -550,11 +550,19 @@ static int handle_signal(int sig, void *data) {
 	case SIGTERM:
 		sway_terminate(0);
 		return 0;
-	case SIGUSR1:
+	case SIGUSR1: {
 		swayidle_log(LOG_DEBUG, "Got SIGUSR1");
 		struct swayidle_timeout_cmd *cmd;
 		wl_list_for_each(cmd, &state.timeout_cmds, link) {
 			register_timeout(cmd, 0);
+		}
+		return 1;
+	}
+	case SIGUSR2: {
+		swayidle_log(LOG_DEBUG, "Got SIGUSR2");
+		struct swayidle_timeout_cmd *cmd;
+		wl_list_for_each(cmd, &state.timeout_cmds, link) {
+			register_timeout(cmd, cmd->timeout);
 		}
 		return 1;
 	}
@@ -596,6 +604,7 @@ int main(int argc, char *argv[]) {
 	wl_event_loop_add_signal(state.event_loop, SIGINT, handle_signal, NULL);
 	wl_event_loop_add_signal(state.event_loop, SIGTERM, handle_signal, NULL);
 	wl_event_loop_add_signal(state.event_loop, SIGUSR1, handle_signal, NULL);
+	wl_event_loop_add_signal(state.event_loop, SIGUSR2, handle_signal, NULL);
 
 	state.display = wl_display_connect(NULL);
 	if (state.display == NULL) {

--- a/main.c
+++ b/main.c
@@ -566,6 +566,9 @@ static int handle_signal(int sig, void *data) {
 		}
 		return 1;
 	}
+	default:
+		swayidle_log(LOG_DEBUG, "Unhandled signal %s", strsignal(sig));
+	}
 	assert(false); // not reached
 }
 

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -30,6 +30,8 @@ command line.
 
 Sending SIGUSR1 to swayidle will immediately enter idle state.
 
+Sending SIGUSR2 to swayidle will reset the timers of timeout commands.
+
 # EVENTS
 
 *timeout* <timeout> <timeout command> [resume <resume command>]


### PR DESCRIPTION
I wrote that patch before I saw the work and discussion in PR #26. That PR is an alternative though. 

Nevertheless, I think it may be interesting to post it. Feel free to ignore it and close it, if it does not make sense to you.

The signal `SIGUSR1` resets the timer to 0 that causes `swaydile` to enter in idle state.

The newly introduced signal `SIGUSR2` does the exact opposite; it resets the timer to *its initial* value that causes `swayidle` to reschedule the entering in idle state (from the begining).

That way, I can use `swayidle` and a small script (basically `killall -SIGUSR2 swayidle` in a loop) to temporarily disable the entering idle state.