### PR TITLE
swayidle.1: remove space from name

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -1,4 +1,4 @@
-swayidle (1)
+swayidle(1)
 
 # NAME
 


### PR DESCRIPTION
This removes the space from `swayidle (1)` in `swayidle.1.scd` since it
is an invalid name character. This is needed to generate the man page
with scdoc 1.9.5 or newer

Related scdoc commit: https://git.sr.ht/~sircmpwn/scdoc/commit/f7fb07006a671d9354f7e1a7b0f0be3e29c120c6