### PR TITLE
Adds logind SetIdleHint event - resolves #4

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -58,6 +58,11 @@ Sending SIGUSR1 to swayidle will immediately enter idle state.
 	If built with systemd support, executes _command_ when logind signals that the
 	session should be unlocked
 
+*idlehint* <timeout>
+	If built with systemd support, set IdleHint to indcate an idle logind/elogind
+	session after <timeout> seconds. Adding an idlehint event will also cause
+	swayidle to call SetIdleHint(false) when run, on resume, unlock, etc.
+
 All commands are executed in a shell.
 
 # EXAMPLE


### PR DESCRIPTION
Adds a new event, `idlehint <seconds>`, which will call the `SetIdleHint` method on the logind session after the delay specified in `<seconds>`. This indicates to logind whether the session is active or idle, allowing logind `IdleAction` to be used.

Adding an `idlehint` event will also cause swayidle to call `SetIdleHint(false)` when first run, on idle resume, unlock, etc. 

This should resolve #4 