### PR TITLE
Add support for logind idle inhibitors

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -33,10 +33,6 @@ swayidle listens for idle activity on your Wayland compositor and executes tasks
 on various idle-related events. You can specify any number of events at the
 command line and in the config file.
 
-Sending SIGUSR1 to swayidle will immediately enter idle state.
-
-When SIGTERM is received swayidle will run all pending resume commands. When finished it will terminate.
-
 # EVENTS
 
 *timeout* <timeout> <timeout command> [resume <resume command>]
@@ -71,6 +67,16 @@ When SIGTERM is received swayidle will run all pending resume commands. When fin
 	swayidle to call SetIdleHint(false) when run, on resume, unlock, etc.
 
 All commands are executed in a shell.
+
+# SIGNALS
+
+swayidle responds to the following signals:
+
+*SIGTERM, SIGINT*
+	Run all pending resume commands. When finished swayidle will terminate.
+
+*SIGUSR1*
+	Immediately enter idle state.
 
 # EXAMPLE
 


### PR DESCRIPTION
Adds support for logind idle inhibitor locks. Specifically:

  * swayidle will disable all idle timers when a logind idle inhibitor lock is found

In addition, a few of the logind functions were rearranged and tweaked to support this feature.

This should resolve issue #38 , and would replace/supercede PR #26 and #40 