### PR TITLE
Set version to 1.7

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'swayidle',
 	'c',
-	version: '1.5',
+	version: '1.7',
 	license: 'MIT',
 	meson_version: '>=0.48.0',
 	default_options: [


### PR DESCRIPTION
It seems this gets forgotten before doing a release.
Like last time:
 * https://github.com/swaywm/swayidle/pull/30
 * https://github.com/swaywm/swayidle/pull/34

So this time I will try differently and set it to the (probably)
next version number :-)