### PR TITLE
Run resume commands on SIGTERM

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -30,6 +30,8 @@ command line.
 
 Sending SIGUSR1 to swayidle will immediately enter idle state.
 
+When SIGTERM is received swayidle will run all pending resume commands. When finished it will terminate.
+
 # EVENTS
 
 *timeout* <timeout> <timeout command> [resume <resume command>]


### PR DESCRIPTION
This executes all pending resumes (in undefined order, see #54 ) when receinving `SIGTERM`.

This is achieved by adding a `boolean resume_pending` to `struct swayidle_timeout_cmd`.

Closes #49 