### PR TITLE
Remove getopt.h include

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,7 +2,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <getopt.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
This isn't provided by POSIX. For getopt, only unistd.h is required.