### PR TITLE
Add config parsing

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@
 #include <wayland-client.h>
 #include <wayland-server.h>
 #include <wayland-util.h>
+#include <wordexp.h>
 #include "config.h"
 #include "idle-client-protocol.h"
 #if HAVE_SYSTEMD
@@ -81,6 +82,7 @@ static void swayidle_log_errno(
 }
 
 static void swayidle_init() {
+	memset(&state, 0, sizeof(state));
 	wl_list_init(&state.timeout_cmds);
 }
 
@@ -89,6 +91,7 @@ static void swayidle_finish() {
 	struct swayidle_timeout_cmd *cmd;
 	struct swayidle_timeout_cmd *tmp;
 	wl_list_for_each_safe(cmd, tmp, &state.timeout_cmds, link) {
+		wl_list_init(&cmd->link);
 		wl_list_remove(&cmd->link);
 		free(cmd);
 	}
@@ -583,10 +586,13 @@ static int parse_idlehint(int argc, char **argv) {
 	return 2;
 }
 
-static int parse_args(int argc, char *argv[]) {
+static int parse_args(int argc, char *argv[], char **config_path) {
 	int c;
-	while ((c = getopt(argc, argv, "hdw")) != -1) {
+	while ((c = getopt(argc, argv, "C:hdw")) != -1) {
 		switch (c) {
+		case 'C':
+			*config_path = strdup(optarg);
+			break;
 		case 'd':
 			verbosity = LOG_DEBUG;
 			break;
@@ -597,6 +603,7 @@ static int parse_args(int argc, char *argv[]) {
 		case '?':
 			printf("Usage: %s [OPTIONS]\n", argv[0]);
 			printf("  -h\tthis help menu\n");
+			printf("  -C\tpath to config file\n");
 			printf("  -d\tdebug\n");
 			printf("  -w\twait for command to finish\n");
 			return 1;
@@ -682,12 +689,109 @@ static int display_event(int fd, uint32_t mask, void *data) {
 	return count;
 }
 
+static char *get_config_path(void) {
+	static char *config_paths[3] = {
+		"$XDG_CONFIG_HOME/swayidle/config",
+		"$HOME/.swayidle/config",
+		SYSCONFDIR "/swayidle/config",
+	};
+
+	char *config_home = getenv("XDG_CONFIG_HOME");
+
+	if (!config_home || config_home[0] == '\n') {
+		config_paths[0] = "$HOME/.config/swayidle/config";
+	}
+
+	wordexp_t p;
+	char *path;
+	for (size_t i = 0; i < sizeof(config_paths) / sizeof(char *); ++i) {
+		if (wordexp(config_paths[i], &p, 0) == 0) {
+			path = strdup(p.we_wordv[0]);
+			wordfree(&p);
+			if (path && access(path, R_OK) == 0) {
+				return path;
+			}
+			free(path);
+		}
+	}
+
+	return NULL;
+}
+
+static int load_config(const char *config_path) {
+	FILE *f = fopen(config_path, "r");
+
+	if (!f) {
+		return -1;
+	}
+
+	size_t lineno = 0;
+	char *line = NULL;
+	size_t n = 0;
+	ssize_t nread;
+	while ((nread = getline(&line, &n, f)) != -1) {
+		lineno++;
+		line[nread-1] = '\0';
+
+		if (strlen(line) == 0 || line[0] == '#') {
+			continue;
+		}
+
+		size_t i = 0;
+		while (line[i] != '\0' && line[i] != ' ') {
+			i++;
+		}
+
+		wordexp_t p;
+		wordexp(line, &p, 0);
+		if (strncmp("timeout", line, i) == 0) {
+			parse_timeout(p.we_wordc, p.we_wordv);
+		} else if (strncmp("before-sleep", line, i) == 0) {
+			parse_sleep(p.we_wordc, p.we_wordv);
+		} else if (strncmp("after-resume", line, i) == 0) {
+			parse_resume(p.we_wordc, p.we_wordv);
+		} else if (strncmp("lock", line, i) == 0) {
+			parse_lock(p.we_wordc, p.we_wordv);
+		} else if (strncmp("unlock", line, i) == 0) {
+			parse_unlock(p.we_wordc, p.we_wordv);
+		} else if (strncmp("idlehint", line, i) == 0) {
+			parse_idlehint(p.we_wordc, p.we_wordv);
+		} else {
+			line[i] = 0;
+			swayidle_log(LOG_ERROR, "Unexpected keyword \"%s\" in line %lu", line, lineno);
+			free(line);
+			return -1;
+		}
+		wordfree(&p);
+	}
+	free(line);
+	fclose(f);
+
+	return 0;
+}
+
+
 int main(int argc, char *argv[]) {
 	swayidle_init();
-	if (parse_args(argc, argv) != 0) {
+	char *config_path = NULL;
+	if (parse_args(argc, argv, &config_path) != 0) {
 		swayidle_finish();
 		return -1;
 	}
+
+	if (!config_path) {
+		config_path = get_config_path();
+	}
+
+	if (load_config(config_path) == -1) {
+		swayidle_finish();
+		swayidle_init();
+		swayidle_log(LOG_DEBUG, "Failed to load config. Starting without it...");
+	} else {
+		swayidle_log(LOG_DEBUG, "Loaded config at %s", config_path);
+	}
+
+	free(config_path);
 
 	state.event_loop = wl_event_loop_create();
 

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,12 @@ add_project_arguments(
 	language: 'c',
 )
 
+sysconfdir = get_option('sysconfdir')
+prefix = get_option('prefix')
+add_project_arguments(
+	'-DSYSCONFDIR="@0@"'.format(join_paths(prefix, sysconfdir)),
+	language : 'c')
+
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -10,6 +10,11 @@ swayidle - Idle manager for Wayland
 
 # OPTIONS
 
+*-C* <path>
+	The config file to use. By default, the following paths are checked in the following order: $XDG_CONFIG_HOME/swayidle/config, $HOME/swayidle/config
+	Config file entries are events as described in the EVENTS section.
+	Specifying events in the config and as arguments is not mutually exclusive.
+
 *-h*
 	Show help message and quit.
 
@@ -26,7 +31,7 @@ swayidle - Idle manager for Wayland
 
 swayidle listens for idle activity on your Wayland compositor and executes tasks
 on various idle-related events. You can specify any number of events at the
-command line.
+command line and in the config file.
 
 Sending SIGUSR1 to swayidle will immediately enter idle state.
 


### PR DESCRIPTION
The config parsing is done by reading the config line by line and converting them to command line arguments with ` wordexp.h`.
This also adds init and finish functions for state.
Closes #17 