### PR TITLE
Fix race condition in get_logind_idle_inhibit()

### DIFF
--- a/main.c
+++ b/main.c
@@ -207,6 +207,8 @@ static void set_idle_hint(bool hint) {
 
 static bool get_logind_idle_inhibit(void) {
 	const char *locks;
+	bool res;
+
 	sd_bus_message *reply = NULL;
 
 	int ret = sd_bus_get_property(bus, DBUS_LOGIND_SERVICE, DBUS_LOGIND_PATH,
@@ -219,8 +221,11 @@ static bool get_logind_idle_inhibit(void) {
 	if (ret < 0) {
 		goto error;
 	}
+
+	res = strstr(locks, "idle") != NULL;
 	sd_bus_message_unref(reply);
-	return strstr(locks, "idle") != NULL;
+
+	return res;
 
 error:
 	sd_bus_message_unref(reply);


### PR DESCRIPTION
See https://github.com/swaywm/swayidle/issues/38#issuecomment-621724409

Running `sd_bus_message_unref()` overrides the `locks` buffer under certain
conditions.

Comparing before running `sd_bus_message_unref()` will make sure that the
inhibit lock will always be found correctly.

@electrickite 