### PR TITLE
fix example: use after-resume

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -87,7 +87,7 @@ swayidle responds to the following signals:
 swayidle -w \
 	timeout 300 'swaylock -f -c 000000' \
 	timeout 600 'swaymsg "output * dpms off"' \
-		resume 'swaymsg "output * dpms on"' \
+		after-resume 'swaymsg "output * dpms on"' \
 	before-sleep 'swaylock -f -c 000000'
 ```
 


### PR DESCRIPTION
hey everyone,

at least for me the given example didn't work (anymore) when using just `resume` instead of `after-resume` and the screen kept dark.

I think this addresses also #47?

greetings
michael