### PR TITLE
Add optional daemonization

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -21,6 +21,9 @@ swayidle - Idle manager for Wayland
 *-d*
 	Enable debug output.
 
+*-f*
+	Fork and daemonize after fully initialized.
+
 *-w*
 	Wait for command to finish executing before continuing, helpful for ensuring
 	that a *before-sleep* command has finished before the system goes to sleep.


### PR DESCRIPTION
If the `-f` argument is passed to swayidle it will fork and daemonize
after initialization. This allows proper ordering of other programs
after swayidle is fully running, including `Type=forking` in systemd units
