### PR TITLE
escape backslashes in manpage example

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -85,9 +85,9 @@ swayidle responds to the following signals:
 
 ```
 swayidle -w \
-	timeout 300 'swaylock -f -c 000000' \
-	timeout 600 'swaymsg "output * dpms off"' \
-		resume 'swaymsg "output * dpms on"' \
+	timeout 300 'swaylock -f -c 000000' \\
+	timeout 600 'swaymsg "output * dpms off"' \\
+		resume 'swaymsg "output * dpms on"' \\
 	before-sleep 'swaylock -f -c 000000'
 ```
 


### PR DESCRIPTION
It appears scdoc requires backslashes to be escaped. Now, the manpage
renders with a single backslash followed by a newline, as opposed to no
backslash.