### PR TITLE
actually fix all manpage backslashes

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -84,7 +84,7 @@ swayidle responds to the following signals:
 # EXAMPLE
 
 ```
-swayidle -w \
+swayidle -w \\
 	timeout 300 'swaylock -f -c 000000' \\
 	timeout 600 'swaymsg "output * dpms off"' \\
 		resume 'swaymsg "output * dpms on"' \\


### PR DESCRIPTION
In the previous commit I forgot to escape the first backslash.