### PR TITLE
Fix last character of config file dropped

### DIFF
--- a/main.c
+++ b/main.c
@@ -927,7 +927,9 @@ static int load_config(const char *config_path) {
 	ssize_t nread;
 	while ((nread = getline(&line, &n, f)) != -1) {
 		lineno++;
-		line[nread-1] = '\0';
+		if (line[nread-1] == '\n') {
+			line[nread-1] = '\0';
+		}
 
 		if (strlen(line) == 0 || line[0] == '#') {
 			continue;


### PR DESCRIPTION
getline returns a string without a newline if the config file doesn't have a final newline.

Closes: #70

Signed-off-by: apiraino <apiraino@users.noreply.github.com>