### PR TITLE
free resume_cmd and idle_cmd at swayidle_finish

### DIFF
--- a/main.c
+++ b/main.c
@@ -103,6 +103,8 @@ static void swayidle_finish() {
 	wl_list_for_each_safe(cmd, tmp, &state.timeout_cmds, link) {
 		wl_list_init(&cmd->link);
 		wl_list_remove(&cmd->link);
+		free(cmd->idle_cmd);
+		free(cmd->resume_cmd);
 		free(cmd);
 	}
 


### PR DESCRIPTION
resume_cmd and idle_cmd members of swayidle_timeout_cmd were never freed
even though the strings are allocated by strdup().