### PR TITLE
Fix clang tidy detections

### DIFF
--- a/main.c
+++ b/main.c
@@ -197,7 +197,6 @@ static void release_inhibitor_lock(int fd) {
 		swayidle_log(LOG_DEBUG, "Releasing inhibitor lock %d", fd);
 		close(fd);
 	}
-	fd = -1;
 }
 
 static void set_idle_hint(bool hint) {

--- a/main.c
+++ b/main.c
@@ -795,6 +795,7 @@ static int parse_args(int argc, char *argv[], char **config_path) {
 	while ((c = getopt(argc, argv, "C:hdwS:")) != -1) {
 		switch (c) {
 		case 'C':
+			free(*config_path);
 			*config_path = strdup(optarg);
 			break;
 		case 'd':
@@ -986,6 +987,7 @@ int main(int argc, char *argv[]) {
 	char *config_path = NULL;
 	if (parse_args(argc, argv, &config_path) != 0) {
 		swayidle_finish();
+		free(config_path);
 		return -1;
 	}
 


### PR DESCRIPTION
I ran clang-tidy against swayidle and it detected several problems. This PR addresses those problems.

However, clang-tidy also warns about the use of `memset` and `sprintf` and suggests to replace them with C11 functions `memset_s` and `sprintf_s` respectively. Those warnings are not addressed in this PR.