### PR TITLE
Fix message handling for PropertiesChanged signal

### DIFF
--- a/main.c
+++ b/main.c
@@ -338,9 +338,21 @@ static int handle_property_changed(sd_bus_message *msg, void *userdata,
 				}
 				return 0;
 			} else {
-				sd_bus_message_skip(msg, "{sv}");
+				ret = sd_bus_message_skip(msg, "v");
+				if (ret < 0) {
+					goto error;
+				}
+			}
+
+			ret = sd_bus_message_exit_container(msg);
+			if (ret < 0) {
+				goto error;
 			}
 		}
+	}
+
+	if (ret < 0) {
+		goto error;
 	}
 
 	return 0;


### PR DESCRIPTION
PropertiesChanged signal dbus message contains an array of elements that
contain two fields:
- First is string type field containing the property name
- Second is variant type field containing the property value

Previously the logic in iterating through these properties and the
fields in them wasn't working properly:
- `sd_bus_message_skip` was called with wrong type and the return value
  of that wasn't checked: it was actually -6 indicating an error
- `sd_bus_exit_container` was not called after each property element and
  before attempting to enter next changed property.

These caused the attempt to enter the second changed property with
`sd_bus_message_enter_container` to fail with -6. And if multiple
properties had been changed, only first of them was actually checked.

This commit fixes the property type for `sd_bus_message_skip` call and
adds the missing `sd_bus_message_exit_container` call. And it also adds
checks for the return value for those two calls and for the
`sd_bus_message_enter_container` call in order to ensure that failures
in the message parsing cause warning messages to be logged.