### PR TITLE
Add conditional timeouts

### DIFF
--- a/main.c
+++ b/main.c
@@ -638,7 +638,8 @@ static void handle_idle(void *data, struct org_kde_kwin_idle_timeout *timer) {
 			cmd_exec(cmd->idle_cmd, state.wait);
 		}
 	} else {
-		register_timeout(cmd, cmd->timeout);
+		// Recheck condition every 5 seconds
+		register_timeout(cmd, 5000);
 	}
 }
 

--- a/main.c
+++ b/main.c
@@ -49,6 +49,7 @@ struct swayidle_timeout_cmd {
 	struct org_kde_kwin_idle_timeout *idle_timer;
 	char *idle_cmd;
 	char *resume_cmd;
+	char *cond_cmd;
 	bool idlehint;
 	bool resume_pending;
 };
@@ -125,6 +126,7 @@ static void swayidle_finish() {
 		wl_list_remove(&cmd->link);
 		free(cmd->idle_cmd);
 		free(cmd->resume_cmd);
+		free(cmd->cond_cmd);
 		free(cmd);
 	}
 
@@ -139,7 +141,7 @@ void sway_terminate(int exit_code) {
 	exit(exit_code);
 }
 
-static void cmd_exec(char *param) {
+static int cmd_exec(char *param) {
 	swayidle_log(LOG_DEBUG, "Cmd exec %s", param);
 	pid_t pid = fork();
 	if (pid == 0) {
@@ -158,6 +160,7 @@ static void cmd_exec(char *param) {
 		exit(0);
 	} else if (pid < 0) {
 		swayidle_log_errno(LOG_ERROR, "fork failed");
+		return pid;
 	} else {
 		swayidle_log(LOG_DEBUG, "Spawned process %s", param);
 		if (state.wait) {
@@ -168,6 +171,7 @@ static void cmd_exec(char *param) {
 		if (state.wait && WIFEXITED(status)) {
 			swayidle_log(LOG_DEBUG, "Process exit status: %d", WEXITSTATUS(status));
 		}
+		return status;
 	}
 }
 
@@ -629,8 +633,12 @@ static void handle_idle(void *data, struct org_kde_kwin_idle_timeout *timer) {
 		set_idle_hint(true);
 	} else
 #endif
-	if (cmd->idle_cmd) {
-		cmd_exec(cmd->idle_cmd);
+	if (!cmd->cond_cmd || cmd_exec(cmd->cond_cmd) == 0) {
+		if (cmd->idle_cmd) {
+			cmd_exec(cmd->idle_cmd);
+		}
+	} else {
+		register_timeout(cmd, cmd->timeout);
 	}
 }
 
@@ -704,10 +712,15 @@ static int parse_timeout(int argc, char **argv) {
 	cmd->idle_cmd = parse_command(argc - 2, &argv[2]);
 
 	int result = 3;
-	if (argc >= 5 && !strcmp("resume", argv[3])) {
+	if (argc >= result + 2 && !strcmp("if", argv[result])) {
+		swayidle_log(LOG_DEBUG, "Setup if");
+		cmd->cond_cmd = parse_command(argc - (result + 1), &argv[result + 1]);
+		result += 2;
+	}
+	if (argc >= result + 2 && !strcmp("resume", argv[result])) {
 		swayidle_log(LOG_DEBUG, "Setup resume");
-		cmd->resume_cmd = parse_command(argc - 4, &argv[4]);
-		result = 5;
+		cmd->resume_cmd = parse_command(argc - (result + 1), &argv[result + 1]);
+		result += 2;
 	}
 	wl_list_insert(&state.timeout_cmds, &cmd->link);
 	return result;


### PR DESCRIPTION
This implements #97.

I made it so the timer is restarted when it gets aborted by the condition. This is of course not perfect since it obviously doesn't react instantly to condition changes. The only way to kind of do that I could think of is if the condition is false once, to periodically check with a short interval (whatever that would be) whether it changed.

Even without the reaction to condition changes I personally find this already quite helpful so my computer doesn't go to standby while I'm listening to some music.

Currently the order of "if" and "resume" is fixed, if has to come before resume, not sure, whether it should be possible to specify those the other way around.