### PR TITLE
Update swayidle.1.scd

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -87,7 +87,7 @@ swayidle responds to the following signals:
 swayidle -w \\
 	timeout 300 'swaylock -f -c 000000' \\
 	timeout 600 'swaymsg "output * dpms off"' \\
-		resume 'swaymsg "output * dpms on"' \\
+	after-resume 'swaymsg "output * dpms on"' \\
 	before-sleep 'swaylock -f -c 000000'
 ```
 


### PR DESCRIPTION
fixed a little typo. 'resume' is not a supported command. 'after-resume' is