### PR TITLE
Add loop action to run periodically commands

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -44,6 +44,10 @@ command line and in the config file.
 	If you specify "resume <resume command>", _resume command_ will be run when
 	there is activity again.
 
+*loop* <timeout> <timeout command>
+	Execute _timeout command_ periodically if there is no activity for <timeout> 
+	seconds.
+
 *before-sleep* <command>
 	If built with systemd support, executes _command_ before systemd puts the
 	computer to sleep.


### PR DESCRIPTION
IIRC, the recommended way already has been declared as : stop swayidle, restart it

But sometime you just want something to run periodically while the wm environment is idle and the only doable way is
to rely on another instance of swayidle to manage the first one. So basically that force the users to build complex process tree of swayidle and to manage pids manually.

This add a simple `loop <timeout> <timeout command>` that close this gap

Related to https://github.com/swaywm/swayidle/issues/97

As an example, here what this patch allow us to do:

```
$ swayidle -w loop 8 'sxmo_screenlock_deeper.sh --idle' \
loop 5 'sxmo_blinkled.sh red blue'
```

Periodically blink and the `sxmo_screenlock_deeper.sh --idle` script would eventually begin hibernation.

Doing this without this new loop verb would be a nightmare: Probably using 4 different swayidle (one per loop, one for each of them to restart the first). Then having a script with a consistant api to start and manage those trees. Then manage signals correctly. It was too much :)