### PR TITLE
Drop logind integration

### DIFF
--- a/completions/bash/swayidle
+++ b/completions/bash/swayidle
@@ -9,7 +9,6 @@ _swayidle()
 
   events=(
     'timeout'
-    'before-sleep'
   )
 
   short=(
@@ -33,10 +32,6 @@ _swayidle()
 
   case "$prev" in
     resume)
-      COMPREPLY=($(compgen -c -- "$cur"))
-      return
-      ;;
-    before-sleep)
       COMPREPLY=($(compgen -c -- "$cur"))
       return
       ;;

--- a/completions/fish/swayidle.fish
+++ b/completions/fish/swayidle.fish
@@ -1,10 +1,8 @@
 # swayidle
-set -l all_events timeout before-sleep after-resume lock unlock idlehint
-set -l cmd_events before-sleep after-resume lock unlock
-set -l time_events idlehint timeout
+set -l all_events timeout
+set -l time_events timeout
 
 complete -c swayidle --arguments "$all_events"
-complete -c swayidle --condition "__fish_seen_subcommand_from $cmd_events" --require-parameter
 complete -c swayidle --condition "__fish_seen_subcommand_from $time_events" --exclusive
 
 complete -c swayidle -s h --description 'show help'

--- a/completions/zsh/_swayidle
+++ b/completions/zsh/_swayidle
@@ -3,8 +3,7 @@
 # Completion script for swayidle
 #
 
-local events=('timeout:Execute timeout command if there is no activity for timeout seconds'
-			  'before-sleep:Execute before-sleep command before sleep')
+local events=('timeout:Execute timeout command if there is no activity for timeout seconds')
 local resume=('resume:Execute command when there is activity again')
 
 if (($#words <= 2)); then
@@ -13,9 +12,6 @@ if (($#words <= 2)); then
 			   '(-h --help)'{-h,--help}'[Show help message and quit]' \
 			   '(-d)'-d'[Enable debug output]' \
 			   '(-w)'-w'[Wait for command to finish executing before continuing]'
-
-elif  [[ "$words[-3]" == before-sleep || "$words[-3]" == resume ]]; then
-	_describe -t "events" 'swayidle' events
 
 elif [[ "$words[-4]" == timeout ]]; then
 		_describe -t "events" 'swayidle' events

--- a/main.c
+++ b/main.c
@@ -14,17 +14,9 @@
 #include <wayland-server.h>
 #include <wayland-util.h>
 #include <wordexp.h>
-#include "config.h"
 #include "idle-client-protocol.h"
 #include "ext-idle-notify-v1-client-protocol.h"
 #include "log.h"
-#if HAVE_SYSTEMD
-#include <systemd/sd-bus.h>
-#include <systemd/sd-login.h>
-#elif HAVE_ELOGIND
-#include <elogind/sd-bus.h>
-#include <elogind/sd-login.h>
-#endif
 
 static struct org_kde_kwin_idle *kde_idle_manager = NULL;
 static struct ext_idle_notifier_v1 *idle_notifier = NULL;
@@ -36,11 +28,6 @@ struct swayidle_state {
 	struct wl_list timeout_cmds; // struct swayidle_timeout_cmd *
 	struct wl_list seats;
 	char *seat_name;
-	char *before_sleep_cmd;
-	char *after_resume_cmd;
-	char *logind_lock_cmd;
-	char *logind_unlock_cmd;
-	bool logind_idlehint;
 	bool timeouts_enabled;
 	bool wait;
 } state;
@@ -52,7 +39,6 @@ struct swayidle_timeout_cmd {
 	struct ext_idle_notification_v1 *idle_notification;
 	char *idle_cmd;
 	char *resume_cmd;
-	bool idlehint;
 	bool resume_pending;
 };
 
@@ -130,9 +116,6 @@ static void swayidle_finish() {
 		free(cmd->resume_cmd);
 		free(cmd);
 	}
-
-	free(state.after_resume_cmd);
-	free(state.before_sleep_cmd);
 }
 
 void sway_terminate(int exit_code) {
@@ -180,351 +163,6 @@ static void cmd_exec(char *param) {
 		}
 	}
 }
-
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-#define DBUS_LOGIND_SERVICE "org.freedesktop.login1"
-#define DBUS_LOGIND_PATH "/org/freedesktop/login1"
-#define DBUS_LOGIND_MANAGER_INTERFACE "org.freedesktop.login1.Manager"
-#define DBUS_LOGIND_SESSION_INTERFACE "org.freedesktop.login1.Session"
-
-static void enable_timeouts(void);
-static void disable_timeouts(void);
-
-static int sleep_lock_fd = -1;
-static struct sd_bus *bus = NULL;
-static char *session_name = NULL;
-
-static void acquire_inhibitor_lock(const char *type, const char *mode,
-	int *fd) {
-	sd_bus_message *msg = NULL;
-	sd_bus_error error = SD_BUS_ERROR_NULL;
-	char why[35];
-
-	sprintf(why, "Swayidle is preventing %s", type);
-	int ret = sd_bus_call_method(bus, DBUS_LOGIND_SERVICE, DBUS_LOGIND_PATH,
-			DBUS_LOGIND_MANAGER_INTERFACE, "Inhibit", &error, &msg,
-			"ssss", type, "swayidle", why, mode);
-	if (ret < 0) {
-		swayidle_log(LOG_ERROR,
-				"Failed to send %s inhibit signal: %s", type, error.message);
-		goto cleanup;
-	}
-
-	ret = sd_bus_message_read(msg, "h", fd);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR,
-				"Failed to parse D-Bus response for %s inhibit", type);
-		goto cleanup;
-	}
-
-	*fd = fcntl(*fd, F_DUPFD_CLOEXEC, 3);
-	if (*fd >= 0) {
-		swayidle_log(LOG_DEBUG, "Got %s lock: %d", type, *fd);
-	} else {
-		swayidle_log_errno(LOG_ERROR, "Failed to copy %s lock fd", type);
-	}
-
-cleanup:
-	sd_bus_error_free(&error);
-	sd_bus_message_unref(msg);
-}
-
-static void release_inhibitor_lock(int fd) {
-	if (fd >= 0) {
-		swayidle_log(LOG_DEBUG, "Releasing inhibitor lock %d", fd);
-		close(fd);
-	}
-}
-
-static void set_idle_hint(bool hint) {
-	swayidle_log(LOG_DEBUG, "SetIdleHint %d", hint);
-	sd_bus_message *msg = NULL;
-	sd_bus_error error = SD_BUS_ERROR_NULL;
-	int ret = sd_bus_call_method(bus, DBUS_LOGIND_SERVICE,
-			session_name, DBUS_LOGIND_SESSION_INTERFACE, "SetIdleHint",
-			&error, &msg, "b", hint);
-	if (ret < 0) {
-		swayidle_log(LOG_ERROR,
-				"Failed to send SetIdleHint signal: %s", error.message);
-	}
-
-	sd_bus_error_free(&error);
-	sd_bus_message_unref(msg);
-}
-
-static bool get_logind_idle_inhibit(void) {
-	const char *locks;
-	bool res;
-
-	sd_bus_message *reply = NULL;
-
-	int ret = sd_bus_get_property(bus, DBUS_LOGIND_SERVICE, DBUS_LOGIND_PATH,
-			DBUS_LOGIND_MANAGER_INTERFACE, "BlockInhibited", NULL, &reply, "s");
-	if (ret < 0) {
-		goto error;
-	}
-
-	ret = sd_bus_message_read_basic(reply, 's', &locks);
-	if (ret < 0) {
-		goto error;
-	}
-
-	res = strstr(locks, "idle") != NULL;
-	sd_bus_message_unref(reply);
-
-	return res;
-
-error:
-	sd_bus_message_unref(reply);
-	errno = -ret;
-	swayidle_log_errno(LOG_ERROR,
-				"Failed to parse get BlockInhibited property");
-	return false;
-}
-
-static int prepare_for_sleep(sd_bus_message *msg, void *userdata,
-		sd_bus_error *ret_error) {
-	/* "b" apparently reads into an int, not a bool */
-	int going_down = 1;
-	int ret = sd_bus_message_read(msg, "b", &going_down);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR,
-				"Failed to parse D-Bus response for Inhibit");
-	}
-	swayidle_log(LOG_DEBUG, "PrepareForSleep signal received %d", going_down);
-	if (!going_down) {
-		acquire_inhibitor_lock("sleep", "delay", &sleep_lock_fd);
-		if (state.after_resume_cmd) {
-			cmd_exec(state.after_resume_cmd);
-		}
-		if (state.logind_idlehint) {
-			set_idle_hint(false);
-		}
-		return 0;
-	}
-
-	if (state.before_sleep_cmd) {
-		cmd_exec(state.before_sleep_cmd);
-	}
-	swayidle_log(LOG_DEBUG, "Prepare for sleep done");
-
-	release_inhibitor_lock(sleep_lock_fd);
-	return 0;
-}
-
-static int handle_lock(sd_bus_message *msg, void *userdata,
-		sd_bus_error *ret_error) {
-	swayidle_log(LOG_DEBUG, "Lock signal received");
-
-	if (state.logind_lock_cmd) {
-		cmd_exec(state.logind_lock_cmd);
-	}
-	swayidle_log(LOG_DEBUG, "Lock command done");
-
-	return 0;
-}
-
-static int handle_unlock(sd_bus_message *msg, void *userdata,
-		sd_bus_error *ret_error) {
-	swayidle_log(LOG_DEBUG, "Unlock signal received");
-
-	if (state.logind_idlehint) {
-		set_idle_hint(false);
-	}
-	if (state.logind_unlock_cmd) {
-		cmd_exec(state.logind_unlock_cmd);
-	}
-	swayidle_log(LOG_DEBUG, "Unlock command done");
-
-	return 0;
-}
-
-static int handle_property_changed(sd_bus_message *msg, void *userdata,
-		sd_bus_error *ret_error) {
-	const char *name;
-	swayidle_log(LOG_DEBUG, "PropertiesChanged signal received");
-
-	int ret = sd_bus_message_read_basic(msg, 's', &name);
-	if (ret < 0) {
-		goto error;
-	}
-
-	if (!strcmp(name, DBUS_LOGIND_MANAGER_INTERFACE)) {
-		swayidle_log(LOG_DEBUG, "Got PropertyChanged: %s", name);
-		ret = sd_bus_message_enter_container(msg, 'a', "{sv}");
-		if (ret < 0) {
-			goto error;
-		}
-
-		const char *prop;
-		while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
-			ret = sd_bus_message_read_basic(msg, 's', &prop);
-			if (ret < 0) {
-				goto error;
-			}
-
-			if (!strcmp(prop, "BlockInhibited")) {
-				if (get_logind_idle_inhibit()) {
-					swayidle_log(LOG_DEBUG, "Logind idle inhibitor found");
-					disable_timeouts();
-				} else {
-					swayidle_log(LOG_DEBUG, "Logind idle inhibitor not found");
-					enable_timeouts();
-				}
-				return 0;
-			} else {
-				ret = sd_bus_message_skip(msg, "v");
-				if (ret < 0) {
-					goto error;
-				}
-			}
-
-			ret = sd_bus_message_exit_container(msg);
-			if (ret < 0) {
-				goto error;
-			}
-		}
-	}
-
-	if (ret < 0) {
-		goto error;
-	}
-
-	return 0;
-
-error:
-	errno = -ret;
-	swayidle_log_errno(LOG_ERROR,
-				"Failed to parse D-Bus response for PropertyChanged");
-	return 0;
-}
-
-static int dbus_event(int fd, uint32_t mask, void *data) {
-	sd_bus *bus = data;
-
-	if ((mask & WL_EVENT_HANGUP) || (mask & WL_EVENT_ERROR)) {
-		sway_terminate(0);
-	}
-
-	int count = 0;
-	if (mask & WL_EVENT_READABLE) {
-		count = sd_bus_process(bus, NULL);
-	}
-	if (mask & WL_EVENT_WRITABLE) {
-		sd_bus_flush(bus);
-	}
-	if (mask == 0) {
-		sd_bus_flush(bus);
-	}
-
-	if (count < 0) {
-		swayidle_log_errno(LOG_ERROR, "sd_bus_process failed, exiting");
-		sway_terminate(0);
-	}
-
-	return count;
-}
-
-static void set_session(void) {
-	sd_bus_message *msg = NULL;
-	sd_bus_error error = SD_BUS_ERROR_NULL;
-	const char *session_name_tmp;
-
-	int ret = sd_bus_call_method(bus, DBUS_LOGIND_SERVICE, DBUS_LOGIND_PATH,
-			DBUS_LOGIND_MANAGER_INTERFACE, "GetSession",
-			&error, &msg, "s", "auto");
-	if (ret < 0) {
-		swayidle_log(LOG_DEBUG,
-				"GetSession failed: %s", error.message);
-		sd_bus_error_free(&error);
-		sd_bus_message_unref(msg);
-
-		ret = sd_bus_call_method(bus, DBUS_LOGIND_SERVICE, DBUS_LOGIND_PATH,
-				DBUS_LOGIND_MANAGER_INTERFACE, "GetSessionByPID",
-				&error, &msg, "u", getpid());
-		if (ret < 0) {
-			swayidle_log(LOG_DEBUG,
-					"GetSessionByPID failed: %s", error.message);
-			swayidle_log(LOG_ERROR,
-					"Failed to find session");
-			goto cleanup;
-		}
-	}
-
-	ret = sd_bus_message_read(msg, "o", &session_name_tmp);
-	if (ret < 0) {
-		swayidle_log(LOG_ERROR,
-				"Failed to read session name");
-		goto cleanup;
-	}
-	session_name = strdup(session_name_tmp);
-	swayidle_log(LOG_DEBUG, "Using session: %s", session_name);
-
-cleanup:
-	sd_bus_error_free(&error);
-	sd_bus_message_unref(msg);
-}
-
-static void connect_to_bus(void) {
-	int ret = sd_bus_default_system(&bus);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to open D-Bus connection");
-		return;
-	}
-	struct wl_event_source *source = wl_event_loop_add_fd(state.event_loop,
-		sd_bus_get_fd(bus), WL_EVENT_READABLE, dbus_event, bus);
-	wl_event_source_check(source);
-	set_session();
-}
-
-static void setup_sleep_listener(void) {
-	int ret = sd_bus_match_signal(bus, NULL, DBUS_LOGIND_SERVICE,
-                DBUS_LOGIND_PATH, DBUS_LOGIND_MANAGER_INTERFACE,
-                "PrepareForSleep", prepare_for_sleep, NULL);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus signal match : sleep");
-		return;
-	}
-	acquire_inhibitor_lock("sleep", "delay", &sleep_lock_fd);
-}
-
-static void setup_lock_listener(void) {
-	int ret = sd_bus_match_signal(bus, NULL, DBUS_LOGIND_SERVICE,
-                session_name, DBUS_LOGIND_SESSION_INTERFACE,
-                "Lock", handle_lock, NULL);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus signal match : lock");
-		return;
-	}
-}
-
-static void setup_unlock_listener(void) {
-	int ret = sd_bus_match_signal(bus, NULL, DBUS_LOGIND_SERVICE,
-                session_name, DBUS_LOGIND_SESSION_INTERFACE,
-                "Unlock", handle_unlock, NULL);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus signal match : unlock");
-		return;
-	}
-}
-
-static void setup_property_changed_listener(void) {
-	int ret = sd_bus_match_signal(bus, NULL, NULL,
-                DBUS_LOGIND_PATH, "org.freedesktop.DBus.Properties",
-                "PropertiesChanged", handle_property_changed, NULL);
-	if (ret < 0) {
-		errno = -ret;
-		swayidle_log_errno(LOG_ERROR, "Failed to add D-Bus signal match : property changed");
-		return;
-	}
-}
-#endif
 
 static void seat_handle_capabilities(void *data, struct wl_seat *seat,
 		uint32_t capabilities) {
@@ -612,12 +250,6 @@ static void enable_timeouts(void) {
 	if (state.timeouts_enabled) {
 		return;
 	}
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-	if (get_logind_idle_inhibit()) {
-		swayidle_log(LOG_INFO, "Not enabling timeouts: idle inhibitor found");
-		return;
-	}
-#endif
 	swayidle_log(LOG_DEBUG, "Enable idle timeouts");
 
 	state.timeouts_enabled = true;
@@ -627,32 +259,9 @@ static void enable_timeouts(void) {
 	}
 }
 
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-static void disable_timeouts(void) {
-	if (!state.timeouts_enabled) {
-		return;
-	}
-	swayidle_log(LOG_DEBUG, "Disable idle timeouts");
-
-	state.timeouts_enabled = false;
-	struct swayidle_timeout_cmd *cmd;
-	wl_list_for_each(cmd, &state.timeout_cmds, link) {
-		destroy_cmd_timer(cmd);
-	}
-	if (state.logind_idlehint) {
-		set_idle_hint(false);
-	}
-}
-#endif
-
 static void handle_idled(struct swayidle_timeout_cmd *cmd) {
 	cmd->resume_pending = true;
 	swayidle_log(LOG_DEBUG, "idle state");
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-	if (cmd->idlehint) {
-		set_idle_hint(true);
-	} else
-#endif
 	if (cmd->idle_cmd) {
 		cmd_exec(cmd->idle_cmd);
 	}
@@ -664,11 +273,6 @@ static void handle_resumed(struct swayidle_timeout_cmd *cmd) {
 	if (cmd->registered_timeout != cmd->timeout) {
 		register_timeout(cmd, cmd->timeout);
 	}
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-	if (cmd->idlehint) {
-		set_idle_hint(false);
-	} else
-#endif
 	if (cmd->resume_cmd) {
 		cmd_exec(cmd->resume_cmd);
 	}
@@ -726,7 +330,6 @@ static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
 
 	struct swayidle_timeout_cmd *cmd =
 		calloc(1, sizeof(struct swayidle_timeout_cmd));
-	cmd->idlehint = false;
 	cmd->resume_pending = false;
 
 	if (seconds > 0) {
@@ -759,111 +362,6 @@ static int parse_timeout(int argc, char **argv) {
 	}
 	wl_list_insert(&state.timeout_cmds, &cmd->link);
 	return result;
-}
-
-static int parse_sleep(int argc, char **argv) {
-#if !HAVE_SYSTEMD && !HAVE_ELOGIND
-	swayidle_log(LOG_ERROR, "%s not supported: swayidle was compiled "
-		       "with neither systemd nor elogind support.", "before-sleep");
-	exit(-1);
-#endif
-	if (argc < 2) {
-		swayidle_log(LOG_ERROR, "Too few parameters to before-sleep command. "
-				"Usage: before-sleep <command>");
-		exit(-1);
-	}
-
-	state.before_sleep_cmd = parse_command(argc - 1, &argv[1]);
-	if (state.before_sleep_cmd) {
-		swayidle_log(LOG_DEBUG, "Setup sleep lock: %s", state.before_sleep_cmd);
-	}
-
-	return 2;
-}
-
-static int parse_resume(int argc, char **argv) {
-#if !HAVE_SYSTEMD && !HAVE_ELOGIND
-	swayidle_log(LOG_ERROR, "%s not supported: swayidle was compiled "
-			"with neither systemd nor elogind support.", "after-resume");
-	exit(-1);
-#endif
-	if (argc < 2) {
-		swayidle_log(LOG_ERROR, "Too few parameters to after-resume command. "
-				"Usage: after-resume <command>");
-		exit(-1);
-	}
-
-	state.after_resume_cmd = parse_command(argc - 1, &argv[1]);
-	if (state.after_resume_cmd) {
-		swayidle_log(LOG_DEBUG, "Setup resume hook: %s", state.after_resume_cmd);
-	}
-
-	return 2;
-}
-
-static int parse_lock(int argc, char **argv) {
-#if !HAVE_SYSTEMD && !HAVE_ELOGIND
-	swayidle_log(LOG_ERROR, "%s not supported: swayidle was compiled"
-			" with neither systemd nor elogind support.", "lock");
-	exit(-1);
-#endif
-	if (argc < 2) {
-		swayidle_log(LOG_ERROR, "Too few parameters to lock command. "
-				"Usage: lock <command>");
-		exit(-1);
-	}
-
-	state.logind_lock_cmd = parse_command(argc - 1, &argv[1]);
-	if (state.logind_lock_cmd) {
-		swayidle_log(LOG_DEBUG, "Setup lock hook: %s", state.logind_lock_cmd);
-	}
-
-	return 2;
-}
-
-static int parse_unlock(int argc, char **argv) {
-#if !HAVE_SYSTEMD && !HAVE_ELOGIND
-	swayidle_log(LOG_ERROR, "%s not supported: swayidle was compiled"
-			" with neither systemd nor elogind support.", "unlock");
-	exit(-1);
-#endif
-	if (argc < 2) {
-		swayidle_log(LOG_ERROR, "Too few parameters to unlock command. "
-				"Usage: unlock <command>");
-		exit(-1);
-	}
-
-	state.logind_unlock_cmd = parse_command(argc - 1, &argv[1]);
-	if (state.logind_unlock_cmd) {
-		swayidle_log(LOG_DEBUG, "Setup unlock hook: %s", state.logind_unlock_cmd);
-	}
-
-	return 2;
-}
-
-static int parse_idlehint(int argc, char **argv) {
-#if !HAVE_SYSTEMD && !HAVE_ELOGIND
-	swayidle_log(LOG_ERROR, "%s not supported: swayidle was compiled"
-			" with neither systemd nor elogind support.", "idlehint");
-	exit(-1);
-#endif
-	if (state.logind_idlehint) {
-		swayidle_log(LOG_ERROR, "Cannot add multiple idlehint events");
-		exit(-1);
-	}
-	if (argc < 2) {
-		swayidle_log(LOG_ERROR, "Too few parameters to idlehint command. "
-				"Usage: idlehint <seconds>");
-		exit(-1);
-	}
-
-	struct swayidle_timeout_cmd *cmd = build_timeout_cmd(argc, argv);
-	cmd->idlehint = true;
-
-	swayidle_log(LOG_DEBUG, "Register idlehint timeout at %d ms", cmd->timeout);
-	wl_list_insert(&state.timeout_cmds, &cmd->link);
-	state.logind_idlehint = true;
-	return 2;
 }
 
 static int parse_args(int argc, char *argv[], char **config_path) {
@@ -902,21 +400,6 @@ static int parse_args(int argc, char *argv[], char **config_path) {
 		if (!strcmp("timeout", argv[i])) {
 			swayidle_log(LOG_DEBUG, "Got timeout");
 			i += parse_timeout(argc - i, &argv[i]);
-		} else if (!strcmp("before-sleep", argv[i])) {
-			swayidle_log(LOG_DEBUG, "Got before-sleep");
-			i += parse_sleep(argc - i, &argv[i]);
-		} else if (!strcmp("after-resume", argv[i])) {
-			swayidle_log(LOG_DEBUG, "Got after-resume");
-			i += parse_resume(argc - i, &argv[i]);
-		} else if (!strcmp("lock", argv[i])) {
-			swayidle_log(LOG_DEBUG, "Got lock");
-			i += parse_lock(argc - i, &argv[i]);
-		} else if (!strcmp("unlock", argv[i])) {
-			swayidle_log(LOG_DEBUG, "Got unlock");
-			i += parse_unlock(argc - i, &argv[i]);
-		} else if (!strcmp("idlehint", argv[i])) {
-			swayidle_log(LOG_DEBUG, "Got idlehint");
-			i += parse_idlehint(argc - i, &argv[i]);
 		} else {
 			swayidle_log(LOG_ERROR, "Unsupported command '%s'", argv[i]);
 			return 1;
@@ -1032,16 +515,6 @@ static int load_config(const char *config_path) {
 		wordexp(line, &p, 0);
 		if (strncmp("timeout", line, i) == 0) {
 			parse_timeout(p.we_wordc, p.we_wordv);
-		} else if (strncmp("before-sleep", line, i) == 0) {
-			parse_sleep(p.we_wordc, p.we_wordv);
-		} else if (strncmp("after-resume", line, i) == 0) {
-			parse_resume(p.we_wordc, p.we_wordv);
-		} else if (strncmp("lock", line, i) == 0) {
-			parse_lock(p.we_wordc, p.we_wordv);
-		} else if (strncmp("unlock", line, i) == 0) {
-			parse_unlock(p.we_wordc, p.we_wordv);
-		} else if (strncmp("idlehint", line, i) == 0) {
-			parse_idlehint(p.we_wordc, p.we_wordv);
 		} else {
 			line[i] = 0;
 			swayidle_log(LOG_ERROR, "Unexpected keyword \"%s\" in line %zu", line, lineno);
@@ -1128,25 +601,6 @@ int main(int argc, char *argv[]) {
 	}
 
 	bool should_run = !wl_list_empty(&state.timeout_cmds);
-#if HAVE_SYSTEMD || HAVE_ELOGIND
-	connect_to_bus();
-	setup_property_changed_listener();
-	if (state.before_sleep_cmd || state.after_resume_cmd) {
-		should_run = true;
-		setup_sleep_listener();
-	}
-	if (state.logind_lock_cmd) {
-		should_run = true;
-		setup_lock_listener();
-	}
-	if (state.logind_unlock_cmd) {
-		should_run = true;
-		setup_unlock_listener();
-	}
-	if (state.logind_idlehint) {
-		set_idle_hint(false);
-	}
-#endif
 	if (!should_run) {
 		swayidle_log(LOG_INFO, "No command specified! Nothing to do, will exit");
 		sway_terminate(0);

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,6 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.27')
 wayland_server = dependency('wayland-server')
 bash_comp      = dependency('bash-completion', required: false)
 fish_comp      = dependency('fish', required: false)
-logind = dependency('lib' + get_option('logind-provider'), required: get_option('logind'))
 
 scdoc = find_program('scdoc', required: get_option('man-pages'))
 wayland_scanner = find_program('wayland-scanner')
@@ -85,17 +84,6 @@ swayidle_deps = [
 	wayland_client,
 	wayland_server,
 ]
-
-conf_data = configuration_data()
-conf_data.set10('HAVE_SYSTEMD', false)
-conf_data.set10('HAVE_ELOGIND', false)
-
-if logind.found()
-	swayidle_deps += logind
-	conf_data.set10('HAVE_' + get_option('logind-provider').to_upper(), true)
-endif
-
-configure_file(output: 'config.h', configuration: conf_data)
 
 executable(
 	'swayidle', [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,4 @@
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
-option('logind', type: 'feature', value: 'auto', description: 'Enable support for logind')
-option('logind-provider', type: 'combo', choices: ['systemd', 'elogind'], value: 'systemd', description: 'Provider of logind support library')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions.')

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -22,8 +22,7 @@ swayidle - Idle manager for Wayland
 	Enable debug output.
 
 *-w*
-	Wait for command to finish executing before continuing, helpful for ensuring
-	that a *before-sleep* command has finished before the system goes to sleep.
+	Wait for command to finish executing before continuing.
 
 	Note: using this option causes swayidle to block until the command finishes.
 
@@ -44,31 +43,6 @@ command line and in the config file.
 	If you specify "resume <resume command>", _resume command_ will be run when
 	there is activity again.
 
-*before-sleep* <command>
-	If built with systemd support, executes _command_ before systemd puts the
-	computer to sleep.
-
-	Note: this only delays sleeping up to the limit set in *logind.conf(5)* by
-	the option InhibitDelayMaxSec. A command that has not finished by then will
-	continue running after resuming from sleep.
-
-*after-resume* <command>
-	If built with systemd support, executes _command_ after logind signals that the
-	computer resumed from sleep.
-
-*lock* <command>
-	If built with systemd support, executes _command_ when logind signals that the
-	session should be locked
-
-*unlock* <command>
-	If built with systemd support, executes _command_ when logind signals that the
-	session should be unlocked
-
-*idlehint* <timeout>
-	If built with systemd support, set IdleHint to indicate an idle logind/elogind
-	session after <timeout> seconds. Adding an idlehint event will also cause
-	swayidle to call SetIdleHint(false) when run, on resume, unlock, etc.
-
 All commands are executed in a shell.
 
 # SIGNALS
@@ -88,12 +62,10 @@ swayidle -w \\
 	timeout 300 'swaylock -f -c 000000' \\
 	timeout 600 'swaymsg "output * dpms off"' \\
 		resume 'swaymsg "output * dpms on"' \\
-	before-sleep 'swaylock -f -c 000000'
 ```
 
 This will lock your screen after 300 seconds of inactivity, then turn off your
 displays after another 300 seconds, and turn your screens back on when resumed.
-It will also lock your screen before your computer goes to sleep.
 
 To make sure swayidle waits for swaylock to lock the screen before it releases the
 inhibition lock, the *-w* options is used in swayidle, and *-f* in swaylock.


### PR DESCRIPTION
This integration is unwanted, as expressed in #117.

Additionally, the integration is not quite correct; to properly launch a
screen locker before sleeping, swayidle should set a suspend inhibitor
**at startup**, and upon the PrepareForSleep signal, it should start the
screen locker and then release the inhibitor lock. The existing
implementation is racey and may run the locker _after_ resuming from
suspend.

Fixes: https://github.com/swaywm/swayidle/issues/117
Closes: https://github.com/swaywm/swayidle/issues/127
Closes: https://github.com/swaywm/swayidle/issues/121
Closes: https://github.com/swaywm/swayidle/issues/64
Closes: https://github.com/swaywm/swayidle/issues/59
Closes: https://github.com/swaywm/swayidle/pull/125
Closes: https://github.com/swaywm/swayidle/pull/89
