### PR TITLE
Replace `dpms` commands with `power` in sample command

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -86,8 +86,8 @@ swayidle responds to the following signals:
 ```
 swayidle -w \\
 	timeout 300 'swaylock -f -c 000000' \\
-	timeout 600 'swaymsg "output * dpms off"' \\
-		resume 'swaymsg "output * dpms on"' \\
+	timeout 600 'swaymsg "output * power off"' \\
+		resume 'swaymsg "output * power on"' \\
 	before-sleep 'swaylock -f -c 000000'
 ```
 


### PR DESCRIPTION
sway-output(5) lists `dpms` as deprecated and an alias for `power`. For
clarity and consistency, the `swayidle(1)` man page should use `power`
in the example command
