### PR TITLE
Add support for OpenBSD / make wordexp optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,10 +53,12 @@ foreach xml : protos
 	protos_src += wayland_scanner_client.process(xml)
 endforeach
 
+cc = meson.get_compiler('c')
 conf_data = configuration_data()
 conf_data.set_quoted('SYSCONFDIR', get_option('prefix') / get_option('sysconfdir'))
 conf_data.set10('HAVE_SYSTEMD', false)
 conf_data.set10('HAVE_ELOGIND', false)
+conf_data.set10('HAVE_WORDEXP', cc.check_header('wordexp.h'))
 
 if logind.found()
 	conf_data.set10('HAVE_' + get_option('logind-provider').to_upper(), true)


### PR DESCRIPTION
like done in swaywm/swaylock#325, replace `wordexp()` usage by handrolled C equivalents - i've been testing it working file with this in `~.config/swayidle/config`:
```
timeout 10 'swaylock -f -c 00ff00'
timeout 20 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"'
```
and it behaves as expected.

The handrolled line parser might be improved, but i've tested it with lines having extra spaces between keywords or trailing spaces.

Feedback welcome !