### PR TITLE
Add an option -r for resetting timeouts on wake-up

### DIFF
--- a/completions/bash/swayidle
+++ b/completions/bash/swayidle
@@ -16,6 +16,7 @@ _swayidle()
     -h
     -d
     -w
+    -r
   )
 
   if [ "$prev" = timeout ]; then

--- a/completions/fish/swayidle.fish
+++ b/completions/fish/swayidle.fish
@@ -10,3 +10,4 @@ complete -c swayidle --condition "__fish_seen_subcommand_from $time_events" --ex
 complete -c swayidle -s h --description 'show help'
 complete -c swayidle -s d --description 'debug'
 complete -c swayidle -s w --description 'wait for command to finish'
+complete -c swayidle -s r --description 'reset timeouts after resuming from sleep'

--- a/completions/zsh/_swayidle
+++ b/completions/zsh/_swayidle
@@ -12,7 +12,8 @@ if (($#words <= 2)); then
 	_arguments -C \
 			   '(-h --help)'{-h,--help}'[Show help message and quit]' \
 			   '(-d)'-d'[Enable debug output]' \
-			   '(-w)'-w'[Wait for command to finish executing before continuing]'
+			   '(-w)'-w'[Wait for command to finish executing before continuing]' \
+			   '(-r)'-r'[Reset timeouts after resuming from sleep]'
 
 elif  [[ "$words[-3]" == before-sleep || "$words[-3]" == resume ]]; then
 	_describe -t "events" 'swayidle' events

--- a/main.c
+++ b/main.c
@@ -41,6 +41,7 @@ struct swayidle_state {
 	bool logind_idlehint;
 	bool timeouts_enabled;
 	bool wait;
+	bool reset_on_resume;
 } state;
 
 struct swayidle_timeout_cmd {
@@ -186,6 +187,7 @@ static void cmd_exec(char *param) {
 
 static void enable_timeouts(void);
 static void disable_timeouts(void);
+static void register_timeout(struct swayidle_timeout_cmd *cmd, int timeout);
 
 static int sleep_lock_fd = -1;
 static struct sd_bus *bus = NULL;
@@ -280,6 +282,17 @@ error:
 	return false;
 }
 
+static void reset_all_timeouts(void) {
+	struct swayidle_timeout_cmd *cmd;
+	wl_list_for_each(cmd, &state.timeout_cmds, link) {
+		if (cmd->resume_pending && cmd->resume_cmd) {
+			cmd_exec(cmd->resume_cmd);
+		}
+		cmd->resume_pending = false;
+		register_timeout(cmd, cmd->timeout);
+	}
+}
+
 static int prepare_for_sleep(sd_bus_message *msg, void *userdata,
 		sd_bus_error *ret_error) {
 	/* "b" apparently reads into an int, not a bool */
@@ -298,6 +311,10 @@ static int prepare_for_sleep(sd_bus_message *msg, void *userdata,
 		}
 		if (state.logind_idlehint) {
 			set_idle_hint(false);
+		}
+		if (state.reset_on_resume) {
+			swayidle_log(LOG_DEBUG, "Reset all timeouts on resume");
+			reset_all_timeouts();
 		}
 		return 0;
 	}
@@ -826,7 +843,7 @@ static int parse_idlehint(int argc, char **argv) {
 
 static int parse_args(int argc, char *argv[], char **config_path) {
 	int c;
-	while ((c = getopt(argc, argv, "C:hdwS:")) != -1) {
+	while ((c = getopt(argc, argv, "C:hdwS:r")) != -1) {
 		switch (c) {
 		case 'C':
 			free(*config_path);
@@ -841,6 +858,9 @@ static int parse_args(int argc, char *argv[], char **config_path) {
 		case 'S':
 			state.seat_name = strdup(optarg);
 			break;
+		case 'r':
+			state.reset_on_resume = true;
+			break;
 		case 'h':
 		case '?':
 			printf("Usage: %s [OPTIONS]\n", argv[0]);
@@ -849,6 +869,7 @@ static int parse_args(int argc, char *argv[], char **config_path) {
 			printf("  -d\tdebug\n");
 			printf("  -w\twait for command to finish\n");
 			printf("  -S\tpick the seat to work with\n");
+			printf("  -r\treset timeouts after resuming from sleep");
 			return 1;
 		default:
 			return 1;

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -30,6 +30,10 @@ swayidle - Idle manager for Wayland
 *-S* <seat-name>
 	Specify which seat to use. By default, if no name is specified, an arbitrary seat will be picked instead.
 
+*-r*
+	If built with systemd support, reset all timeouts after logind signals that
+	the computer resumed from sleep, i.e. treat wake-up signals as activities.
+
 # DESCRIPTION
 
 swayidle listens for idle activity on your Wayland compositor and executes tasks


### PR DESCRIPTION
This is useful for re-suspending the system when there is no activity after waking up. Fixes #144.