### PR TITLE
Add a missing stop in the manpage

### DIFF
--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -11,7 +11,7 @@ swayidle - Idle manager for Wayland
 # OPTIONS
 
 *-C* <path>
-	The config file to use. By default, the following paths are checked in the following order: $XDG_CONFIG_HOME/swayidle/config, $HOME/swayidle/config
+	The config file to use. By default, the following paths are checked in the following order: $XDG_CONFIG_HOME/swayidle/config, $HOME/swayidle/config.
 	Config file entries are events as described in the EVENTS section.
 	Specifying events in the config and as arguments is not mutually exclusive.
 


### PR DESCRIPTION
A stop is missing in the manpage. This pull request adds it.

![image](https://github.com/swaywm/swayidle/assets/31312212/c0066c46-9a40-4a5d-83cd-6667064dc33e)
