### PR TITLE
Allow to ignore idle inhibitors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ add_project_arguments([
 ], language: 'c')
 
 wayland_client = dependency('wayland-client')
-wayland_protos = dependency('wayland-protocols', version: '>=1.27')
+wayland_protos = dependency('wayland-protocols', version: '>=1.40')
 wayland_server = dependency('wayland-server')
 logind = dependency('lib' + get_option('logind-provider'), required: get_option('logind'))
 scdoc = find_program('scdoc', required: get_option('man-pages'))


### PR DESCRIPTION
fixes #51

The idle-notify protocol [recently gained](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/367) a new method get_input_idle_notification() that allows to ignore idle inhibitors. I didn't want to change the behavior of SIGUSR1 to keep backwards compatibility, so I added SIGUSR2 with the new behavior.

I was also unsure whether to add a boolean argument to `register_timeout` or add a new function. I went with the former option.