### PR TITLE
ci: test builds with and without logind

### DIFF
--- a/.builds/with-logind.yml
+++ b/.builds/with-logind.yml
@@ -1,16 +1,16 @@
 image: alpine/edge
 packages:
+  - elogind-dev
   - meson
+  - scdoc
   - wayland-dev
   - wayland-protocols
-  - scdoc
 sources:
   - https://github.com/swaywm/swayidle
 tasks:
   - setup: |
       cd swayidle
-      meson build
+      meson -Dlogind=enabled build
   - build: |
       cd swayidle
       ninja -C build
-

--- a/.builds/without-logind.yml
+++ b/.builds/without-logind.yml
@@ -1,0 +1,15 @@
+image: alpine/edge
+packages:
+  - meson
+  - wayland-dev
+  - wayland-protocols
+  - scdoc
+sources:
+  - https://github.com/swaywm/swayidle
+tasks:
+  - setup: |
+      cd swayidle
+      meson build
+  - build: |
+      cd swayidle
+      ninja -C build


### PR DESCRIPTION
A recent patch revealed that CI won't detect obvious build errors for portions of code that only build with logind.

Run two CI jobs: one without logind, and one with logind.