### PR TITLE
Use bright black rather than black for LOG_DEBUG

### DIFF
--- a/main.c
+++ b/main.c
@@ -64,7 +64,7 @@ static const char *verbosity_colors[] = {
 	[LOG_SILENT] = "",
 	[LOG_ERROR ] = "\x1B[1;31m",
 	[LOG_INFO  ] = "\x1B[1;34m",
-	[LOG_DEBUG ] = "\x1B[1;30m",
+	[LOG_DEBUG ] = "\x1B[1;90m",
 };
 
 static enum log_importance log_importance = LOG_INFO;


### PR DESCRIPTION
On some terminals under default settings, black is truly rendered as `#000`, making it unreadable when the background is also black.

Taken from sway commit c632d47bf811d246ea2f4874e6dda6b85a3b95ff.

Closes: https://github.com/swaywm/swayidle/issues/199