### PR TITLE
Add support for input-timeout through input_idle_notification

### DIFF
--- a/completions/bash/swayidle
+++ b/completions/bash/swayidle
@@ -9,6 +9,7 @@ _swayidle()
 
   events=(
     'timeout'
+    'input-timeout'
     'before-sleep'
   )
 
@@ -18,15 +19,15 @@ _swayidle()
     -w
   )
 
-  if [ "$prev" = timeout ]; then
-    # timeout <timeout>
+  if [ "$prev" = timeout ] || [ "$prev" = input-timeout ]; then
+    # (input-)timeout <timeout>
     return
-  elif [ "$prev2" = timeout ]; then
-    # timeout <timeout> <timeout command>
+  elif [ "$prev2" = timeout ] || [ "$prev2" = input-timeout ]; then
+    # (input-)timeout <timeout> <timeout command>
     COMPREPLY=($(compgen -c -- "$cur"))
     return
-  elif [ "$prev3" = timeout ]; then
-    # timeout <timeout> <timeout command> [resume <resume command>]
+  elif [ "$prev3" = timeout ] || [ "$prev3" = input-timeout ]; then
+    # (input-)timeout <timeout> <timeout command> [resume <resume command>]
     COMPREPLY=(resume)
     # optional argument; no return here as user may skip 'resume'
   fi

--- a/completions/fish/swayidle.fish
+++ b/completions/fish/swayidle.fish
@@ -1,7 +1,7 @@
 # swayidle
-set -l all_events timeout before-sleep after-resume lock unlock idlehint
+set -l all_events timeout input-timeout before-sleep after-resume lock unlock idlehint
 set -l cmd_events before-sleep after-resume lock unlock
-set -l time_events idlehint timeout
+set -l time_events idlehint timeout input-timeout
 
 complete -c swayidle --arguments "$all_events"
 complete -c swayidle --condition "__fish_seen_subcommand_from $cmd_events" --require-parameter

--- a/completions/zsh/_swayidle
+++ b/completions/zsh/_swayidle
@@ -4,6 +4,7 @@
 #
 
 local events=('timeout:Execute timeout command if there is no activity for timeout seconds'
+			  'input-timeout:Execute timeout command if there is user input no activity for timeout seconds'
 			  'before-sleep:Execute before-sleep command before sleep')
 local resume=('resume:Execute command when there is activity again')
 
@@ -17,7 +18,7 @@ if (($#words <= 2)); then
 elif  [[ "$words[-3]" == before-sleep || "$words[-3]" == resume ]]; then
 	_describe -t "events" 'swayidle' events
 
-elif [[ "$words[-4]" == timeout ]]; then
+elif [[ "$words[-4]" == timeout ||  "$words[-4]" == input-timeout  ]]; then
 		_describe -t "events" 'swayidle' events
 		_describe -t "resume" 'swayidle' resume
 fi

--- a/main.c
+++ b/main.c
@@ -42,13 +42,19 @@ struct swayidle_state {
 	bool wait;
 } state;
 
+enum swayidle_timeout_type {
+	TIMEOUT_TYPE_REGULAR,
+	TIMEOUT_TYPE_IDLE_HINT,
+	TIMEOUT_TYPE_INPUT_IDLE,
+};
+
 struct swayidle_timeout_cmd {
 	struct wl_list link;
+	enum swayidle_timeout_type type;
 	int timeout, registered_timeout;
 	struct ext_idle_notification_v1 *idle_notification;
 	char *idle_cmd;
 	char *resume_cmd;
-	bool idlehint;
 	bool resume_pending;
 };
 
@@ -542,8 +548,8 @@ static const struct wl_seat_listener wl_seat_listener = {
 static void handle_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *interface, uint32_t version) {
 	if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
-		idle_notifier =
-			wl_registry_bind(registry, name, &ext_idle_notifier_v1_interface, 1);
+		idle_notifier = wl_registry_bind(registry, name,
+				&ext_idle_notifier_v1_interface, version >= 2 ? 2 : 1);
 	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
 		struct seat *s = calloc(1, sizeof(struct seat));
 		s->proxy = wl_registry_bind(registry, name, &wl_seat_interface, 2);
@@ -580,9 +586,17 @@ static void register_timeout(struct swayidle_timeout_cmd *cmd,
 		swayidle_log(LOG_DEBUG, "Not registering idle timeout");
 		return;
 	}
-	swayidle_log(LOG_DEBUG, "Register with timeout: %d", timeout);
+
 	uint32_t version = ext_idle_notifier_v1_get_version(idle_notifier);
-	if (obey_inhibitors || version < EXT_IDLE_NOTIFIER_V1_GET_INPUT_IDLE_NOTIFICATION_SINCE_VERSION) {
+	if (cmd->type == TIMEOUT_TYPE_INPUT_IDLE
+			&& version < EXT_IDLE_NOTIFIER_V1_GET_INPUT_IDLE_NOTIFICATION_SINCE_VERSION) {
+		swayidle_log(LOG_DEBUG, "Not registering input idle timeout");
+		return;
+	}
+
+	swayidle_log(LOG_DEBUG, "Register with timeout: %d", timeout);
+	if (cmd->type != TIMEOUT_TYPE_INPUT_IDLE
+			&& (obey_inhibitors || version < EXT_IDLE_NOTIFIER_V1_GET_INPUT_IDLE_NOTIFICATION_SINCE_VERSION)) {
 		cmd->idle_notification = ext_idle_notifier_v1_get_idle_notification(
 			idle_notifier, timeout, seat);
 	} else {
@@ -594,13 +608,26 @@ static void register_timeout(struct swayidle_timeout_cmd *cmd,
 	cmd->registered_timeout = timeout;
 }
 
+static void enable_inactive_input_timeouts() {
+	swayidle_log(LOG_DEBUG, "Enable input idle timeouts");
+	struct swayidle_timeout_cmd *cmd;
+	wl_list_for_each(cmd, &state.timeout_cmds, link) {
+		if (cmd->type == TIMEOUT_TYPE_INPUT_IDLE
+				&& cmd->idle_notification == NULL) {
+			register_timeout(cmd, cmd->timeout, true);
+		}
+	}
+}
+
 static void enable_timeouts(void) {
 	if (state.timeouts_enabled) {
+		enable_inactive_input_timeouts();
 		return;
 	}
 #if HAVE_SYSTEMD || HAVE_ELOGIND
 	if (get_logind_idle_inhibit()) {
 		swayidle_log(LOG_INFO, "Not enabling timeouts: idle inhibitor found");
+		enable_inactive_input_timeouts();
 		return;
 	}
 #endif
@@ -609,6 +636,11 @@ static void enable_timeouts(void) {
 	state.timeouts_enabled = true;
 	struct swayidle_timeout_cmd *cmd;
 	wl_list_for_each(cmd, &state.timeout_cmds, link) {
+		if (cmd->type == TIMEOUT_TYPE_INPUT_IDLE
+				&& cmd->idle_notification != NULL) {
+			// Skip already active input idle timeouts
+			continue;
+		}
 		register_timeout(cmd, cmd->timeout, true);
 	}
 }
@@ -623,7 +655,9 @@ static void disable_timeouts(void) {
 	state.timeouts_enabled = false;
 	struct swayidle_timeout_cmd *cmd;
 	wl_list_for_each(cmd, &state.timeout_cmds, link) {
-		destroy_cmd_timer(cmd);
+		if (cmd->type != TIMEOUT_TYPE_INPUT_IDLE) {
+			destroy_cmd_timer(cmd);
+		}
 	}
 	if (state.logind_idlehint) {
 		set_idle_hint(false);
@@ -636,7 +670,7 @@ static void handle_idled(void *data, struct ext_idle_notification_v1 *notif) {
 	cmd->resume_pending = true;
 	swayidle_log(LOG_DEBUG, "idle state");
 #if HAVE_SYSTEMD || HAVE_ELOGIND
-	if (cmd->idlehint) {
+	if (cmd->type == TIMEOUT_TYPE_IDLE_HINT) {
 		set_idle_hint(true);
 	} else
 #endif
@@ -653,7 +687,7 @@ static void handle_resumed(void *data, struct ext_idle_notification_v1 *notif) {
 		register_timeout(cmd, cmd->timeout, true);
 	}
 #if HAVE_SYSTEMD || HAVE_ELOGIND
-	if (cmd->idlehint) {
+	if (cmd->type == TIMEOUT_TYPE_IDLE_HINT) {
 		set_idle_hint(false);
 	} else
 #endif
@@ -677,7 +711,8 @@ static char *parse_command(int argc, char **argv) {
 	return strdup(argv[0]);
 }
 
-static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
+static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv,
+		enum swayidle_timeout_type type) {
 	errno = 0;
 	char *endptr;
 	int seconds = strtoul(argv[1], &endptr, 10);
@@ -689,7 +724,7 @@ static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
 
 	struct swayidle_timeout_cmd *cmd =
 		calloc(1, sizeof(struct swayidle_timeout_cmd));
-	cmd->idlehint = false;
+	cmd->type = type;
 	cmd->resume_pending = false;
 
 	if (seconds > 0) {
@@ -701,16 +736,21 @@ static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
 	return cmd;
 }
 
-static int parse_timeout(int argc, char **argv) {
+static int parse_timeout(int argc, char **argv, bool is_input_timeout) {
 	if (argc < 3) {
 		swayidle_log(LOG_ERROR, "Too few parameters to timeout command. "
 				"Usage: timeout <seconds> <command>");
 		exit(-1);
 	}
 
-	struct swayidle_timeout_cmd *cmd = build_timeout_cmd(argc, argv);
+	struct swayidle_timeout_cmd *cmd = build_timeout_cmd(argc, argv,
+			is_input_timeout ? TIMEOUT_TYPE_INPUT_IDLE : TIMEOUT_TYPE_REGULAR);
 
-	swayidle_log(LOG_DEBUG, "Register idle timeout at %d ms", cmd->timeout);
+	if (!is_input_timeout) {
+		swayidle_log(LOG_DEBUG, "Register idle timeout at %d ms", cmd->timeout);
+	} else {
+		swayidle_log(LOG_DEBUG, "Register input idle timeout at %d ms", cmd->timeout);
+	}
 	swayidle_log(LOG_DEBUG, "Setup idle");
 	cmd->idle_cmd = parse_command(argc - 2, &argv[2]);
 
@@ -820,8 +860,7 @@ static int parse_idlehint(int argc, char **argv) {
 		exit(-1);
 	}
 
-	struct swayidle_timeout_cmd *cmd = build_timeout_cmd(argc, argv);
-	cmd->idlehint = true;
+	struct swayidle_timeout_cmd *cmd = build_timeout_cmd(argc, argv, TIMEOUT_TYPE_IDLE_HINT);
 
 	swayidle_log(LOG_DEBUG, "Register idlehint timeout at %d ms", cmd->timeout);
 	wl_list_insert(&state.timeout_cmds, &cmd->link);
@@ -864,7 +903,10 @@ static int parse_args(int argc, char *argv[], char **config_path) {
 	while (i < argc) {
 		if (!strcmp("timeout", argv[i])) {
 			swayidle_log(LOG_DEBUG, "Got timeout");
-			i += parse_timeout(argc - i, &argv[i]);
+			i += parse_timeout(argc - i, &argv[i], false);
+		} else if (!strcmp("input-timeout", argv[i])) {
+			swayidle_log(LOG_DEBUG, "Got input-timeout");
+			i += parse_timeout(argc - i, &argv[i], true);
 		} else if (!strcmp("before-sleep", argv[i])) {
 			swayidle_log(LOG_DEBUG, "Got before-sleep");
 			i += parse_sleep(argc - i, &argv[i]);
@@ -1021,7 +1063,9 @@ static int load_config(const char *config_path) {
 		}
 
 		if (strncmp("timeout", line, i) == 0) {
-			parse_timeout(p.we_wordc, p.we_wordv);
+			parse_timeout(p.we_wordc, p.we_wordv, false);
+		} else if (strncmp("input-timeout", line, i) == 0) {
+			parse_timeout(p.we_wordc, p.we_wordv, true);
 		} else if (strncmp("before-sleep", line, i) == 0) {
 			parse_sleep(p.we_wordc, p.we_wordv);
 		} else if (strncmp("after-resume", line, i) == 0) {

--- a/swayidle.1.scd
+++ b/swayidle.1.scd
@@ -44,6 +44,13 @@ command line and in the config file.
 	If you specify "resume <resume command>", _resume command_ will be run when
 	there is activity again.
 
+*input-timeout* <timeout> <timeout command> [resume <resume command>]
+	Execute _timeout command_ if there is no user input activity for <timeout> seconds.
+	Note, this ignores any idle inhibitors and requires support for *ext_idle_notifier_v1* version 2.
+
+	If you specify "resume <resume command>", _resume command_ will be run when
+	there is input activity again.
+
 *before-sleep* <command>
 	If built with systemd support, executes _command_ before systemd puts the
 	computer to sleep.


### PR DESCRIPTION
Adds support for `ext_idle_notifier_v1::get_input_idle_notification` by adding `input-timeout` as another timeout command. It's just like the regular `timeout` command, but only idles by lack of user input and it ignores idle inhibitors like the [Wayland protocol](https://wayland.app/protocols/ext-idle-notify-v1#ext_idle_notifier_v1:request:get_input_idle_notification) specifies.

This allows me to dim my OLED display when I'm not at my system, while idle inhibited.