### PR TITLE
allow timeout delay to be set as float

### DIFF
--- a/main.c
+++ b/main.c
@@ -680,10 +680,10 @@ static char *parse_command(int argc, char **argv) {
 static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
 	errno = 0;
 	char *endptr;
-	int seconds = strtoul(argv[1], &endptr, 10);
+	float seconds = strtof(argv[1], &endptr);
 	if (errno != 0 || *endptr != '\0') {
 		swayidle_log(LOG_ERROR, "Invalid %s parameter '%s', it should be a "
-				"numeric value representing seconds", argv[0], argv[1]);
+				"float value representing seconds", argv[0], argv[1]);
 		exit(-1);
 	}
 
@@ -693,7 +693,7 @@ static struct swayidle_timeout_cmd *build_timeout_cmd(int argc, char **argv) {
 	cmd->resume_pending = false;
 
 	if (seconds > 0) {
-		cmd->timeout = seconds * 1000;
+		cmd->timeout = (int)(seconds * 1000);
 	} else {
 		cmd->timeout = -1;
 	}


### PR DESCRIPTION
thanks for this tool!

since the timeout struct internally uses milliseconds, i've adjusted swayidle to allow the user to set the timeout in seconds using a `float`.
this is backward compatible to existing invocations using `int`.

my usecase: have a keybinding to quickly turn off the monitor, but waking it up again with activity:

``` bash
# turn off the monitors, wake up on activity
# similar to `xset dpms force off` on X
bindsym $mod+o exec swayidle -w timeout 0.2 'swaymsg "output * power off"' resume 'swaymsg "output * power on"; kill $PPID'
```

the current implementation has a minimum wait time of 1s, but with this patch, you can go quicker :)

(the hack killing swayidle with `kill $PPID` could also be improved by exiting swayidle when the timeout/resume command exit with a special return code, for example)